### PR TITLE
Get (approximate) pattern match count without fetching results

### DIFF
--- a/lib/levelgraph.js
+++ b/lib/levelgraph.js
@@ -109,6 +109,13 @@ module.exports = function levelgraph(leveldb, options, readyCallback) {
     return db.search(a, b, c);
   };
 
+  db.approximateSize = function(pattern, callback) {
+    var query = utilities.createQuery(utilities.queryMask(pattern));
+    leveldb.db.approximateSize(query.start, query.end, function (error, size) {
+      callback(error, error ? null : size >> 8);
+    });
+  };
+
   if (callTheCallback && readyCallback) {
     process.nextTick(readyCallback.bind(null, null, db));
   }

--- a/test/triple_store_spec.js
+++ b/test/triple_store_spec.js
@@ -300,6 +300,23 @@ describe('a basic triple store', function() {
     });
   });
 
+  describe('with 10 triples inserted', function() {
+    beforeEach(function (done) {
+      var triples = [];
+      for (var i = 0; i < 10; i++) {
+        triples[i] = { subject: 's', predicate: 'p', object: 'o' + i };
+      }
+      db.put(triples, done);
+    });
+
+    it('should return the approximate size', function(done) {
+      db.approximateSize({ predicate: 'b' }, function (err, size) {
+        expect(size).to.be.a('number');
+        done(err);
+      });
+    });
+  });
+
   it('should put triples using a stream', function(done) {
     var t1 = { subject: 'a', predicate: 'b', object: 'c' };
     var t2 = { subject: 'a', predicate: 'b', object: 'd' };


### PR DESCRIPTION
For the moment, we have to [iterate through all the results](https://github.com/LinkedDataFragments/Server/blob/v0.2.3/lib/LevelGraphDatasource.js#L23) to know how many triples match.

Would it be possible to have a method to retrieve (approximate) counts for a pattern?
