### PR TITLE
Add missing `tmp` dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "setimmediate": "^1.0.2",
     "sinon": "^2.3.2",
     "sinon-chai": "^2.10.0",
+    "tmp": "0.0.33",    
     "uglify-js": "^3.0.15",
     "zuul": "^3.0.0"
   },


### PR DESCRIPTION
`tmp` is used here: https://github.com/levelgraph/levelgraph/blob/master/examples/foaf.js#L4