### PR TITLE
Unshare join defaults across runs, since it can yield incorrect answers if the object is modified

### DIFF
--- a/lib/levelgraph.js
+++ b/lib/levelgraph.js
@@ -43,9 +43,11 @@ var filterStream = require('./filterstream')
   , doAction
   , doActionStream;
 
-var joinDefaults = {
-  solution: {}
-};
+function joinDefaults() {
+  return {
+    solution: {}
+  };
+}
 
 module.exports = function levelgraph(leveldb, options) {
 
@@ -121,7 +123,7 @@ searchStream = function(db, options) {
     var that = this
       , result = new PassThrough({ objectMode: true });
 
-    options = extend(joinDefaults, options);
+    options = extend(joinDefaults(), options);
 
     if (!query || query.length === 0) {
       result.end();


### PR DESCRIPTION
This was a hellish bug to track down, but something further in my application (or perhaps levelgraph-jsonld) is modifying the `solution` object within `joinDefaults`. This led to a spurious, impossible-to-satisfy filter, ending up with the query returning no results. With this patch applied, it fetches the correct data, never re-using a solution from some other state.