### PR TITLE
Replaced start..end by gte..lte

### DIFF
--- a/lib/levelgraph.js
+++ b/lib/levelgraph.js
@@ -104,7 +104,7 @@ module.exports = function levelgraph(leveldb, options) {
 
   db.approximateSize = function(pattern, callback) {
     var query = utilities.createQuery(utilities.queryMask(pattern));
-    leveldb.db.approximateSize(query.start, query.end, function (error, size) {
+    leveldb.db.approximateSize(query.gte, query.lte, function (error, size) {
       callback(error, error ? null : size >> 8);
     });
   };

--- a/lib/queryplanner.js
+++ b/lib/queryplanner.js
@@ -49,7 +49,7 @@ function queryplanner(db, options) {
         , range = utilities.createQuery(newq);
 
       if (db.db && db.db.approximateSize) {
-        db.db.approximateSize(range.start, range.end, function(err, size) {
+        db.db.approximateSize(range.gte, range.lte, function(err, size) {
           if (err) {
             size = Object.keys(variablesMask(q)).length;
           }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -161,11 +161,9 @@ function createQuery(pattern, options) {
     , key = genKey(index, pattern, '')
     , limit = pattern.limit
     , reverse = pattern.reverse || false
-    , start = reverse ? applyUpperBoundChar(key) : key
-    , end = reverse ? key : applyUpperBoundChar(key)
     , query = {
-          start: start
-        , end: end
+          gte: key
+        , lte: applyUpperBoundChar(key)
         , reverse: reverse
         , fillCache: true
         , limit: typeof limit === 'number' && limit || -1


### PR DESCRIPTION
As mentioned in #188 , the range notation during the opening of streams has been updated in leveldb. Leveldb now requires streams to be opened with `gte`, `lte`, `lt`, etc instead of using `start` and `end`.

The references to these have been updates (see files changed).

Because automated tests are not functional at the moment, I've recorded the tests running using asciinema and ran some manual tests (which used to fail due to the range notation), but feel free to verify the results yourself.

Asciinema: https://asciinema.org/a/430225

Manual operations (from for-now private project, all levelgraph operations were logged), which work as expected:
```
PUT { subject: 'DEADBEEF', predicate: 'name', object: 'finwo' }
PUT { subject: 'DEADBEEF', predicate: 'likes', object: 'coffee' }
PUT { subject: 'DEADBEEF', predicate: 'likes', object: 'pizza' }
PUT { subject: 'DEADBEEF', predicate: 'type', object: 'Account' }
PUT { subject: 'FOOBAR', predicate: 'name', object: 'matteo' }
PUT { subject: 'FOOBAR', predicate: 'likes', object: 'coffee' }
PUT { subject: 'FOOBAR', predicate: 'likes', object: 'pizza' }
PUT { subject: 'FOOBAR', predicate: 'type', object: 'Account' }
SEARCH [
  {
    subject: Variable { name: 's' },
    predicate: 'type',
    object: 'Account'
  },
  {
    subject: Variable { name: 's' },
    predicate: 'likes',
    object: 'coffee'
  },
  {
    subject: Variable { name: 's' },
    predicate: Variable { name: 'p' },
    object: Variable { name: 'o' }
  }
]
RESULT [
  { s: 'DEADBEEF', p: 'likes', o: 'coffee' },
  { s: 'DEADBEEF', p: 'likes', o: 'pizza' },
  { s: 'DEADBEEF', p: 'name', o: 'finwo' },
  { s: 'DEADBEEF', p: 'type', o: 'Account' },
  { s: 'FOOBAR', p: 'likes', o: 'coffee' },
  { s: 'FOOBAR', p: 'likes', o: 'pizza' },
  { s: 'FOOBAR', p: 'name', o: 'matteo' },
  { s: 'FOOBAR', p: 'type', o: 'Account' }
]
SEARCH [
  {
    subject: Variable { name: 's' },
    predicate: 'type',
    object: 'Account'
  },
  {
    subject: Variable { name: 's' },
    predicate: 'name',
    object: 'finwo'
  },
  {
    subject: Variable { name: 's' },
    predicate: Variable { name: 'p' },
    object: Variable { name: 'o' }
  }
]
RESULT [
  { s: 'DEADBEEF', p: 'likes', o: 'coffee' },
  { s: 'DEADBEEF', p: 'likes', o: 'pizza' },
  { s: 'DEADBEEF', p: 'name', o: 'finwo' },
  { s: 'DEADBEEF', p: 'type', o: 'Account' }
]
```