### PR TITLE
Ci on prs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,10 +3,10 @@ name: Tests
 on:
   pull_request:
     branches:
-      - master
+      - 'master'
   push:
     branches:
-      - *
+      - '*'
 
 jobs:
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: push
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - *
 
 jobs:
 


### PR DESCRIPTION
Although CI did run on the fork, the status was not shown in PRs on the main repository.

This rewrite of the `on` trigger should trigger another time on a PR, allowing github to better match the action run to a PR.