### PR TITLE
Fix queryplanner test

### DIFF
--- a/test/memdb/queryplanner_spec.js
+++ b/test/memdb/queryplanner_spec.js
@@ -112,7 +112,7 @@ describe('query planner', function() {
         .yields(null, 10);
 
       planner(query, function(err, result) {
-        expect(result).to.eql(query);
+        expect(result).to.eql(expected);
         done();
       });
     });


### PR DESCRIPTION
__Note:__ I have not re-run/confirmed tests with this change yet; I ran across this seemingly wrong code in the process of a bigger changeset, and could not easily test in isolation. This PR is mostly so that I don't forget to report it, though feel free to merge if the change looks correct.

This makes a small change to one of the queryplanner tests; currently it seems to be testing the queryplanner output against the query input, rather than against the expected output. I could not find a reason why it would be testing against the query input, so I figured it was probably just a typo.